### PR TITLE
Correção título e nomes em alguns tópicos

### DIFF
--- a/guiadobackend-main/README.md
+++ b/guiadobackend-main/README.md
@@ -365,7 +365,7 @@ Abaixo você encontrará conteúdos para te guiar e ajudar a se torna um desenvo
 > Raspberry Pi é uma série de mini-computadores de placa única multiplataforma, de tamanho reduzido com componentes integrados, que se conecta a um monitor de computador ou televisão, e usa um teclado e um mouse padrão.
 
 - [Raspberry Pi - W3Schools](https://www.w3schools.com/nodejs/nodejs_raspberrypi.asp) - W3Schools é um site educacional voltado ao aprendizado de tecnologias web. Seu conteúdo inclui tutoriais e referências relacionadas a diversas linguagens.
-- [Documentação do Raspberry Pi](https://www.raspberrypi.com/documentation/) - Documentação Oficial do PostgreeSQL em inglês
+- [Documentação do Raspberry Pi](https://www.raspberrypi.com/documentation/) - Documentação Oficial do Raspberry Pi em inglês
 - [Curso de Raspberry Pi](#) - Cursos de Raspberry Pi diretamente do repositório geral do Guia Dev Brasil.
 
 ## ◾ AWS Cloud

--- a/guiadobackend-main/README.md
+++ b/guiadobackend-main/README.md
@@ -319,13 +319,13 @@ Abaixo você encontrará conteúdos para te guiar e ajudar a se torna um desenvo
 - [Documentação do MongoDB](https://www.mongodb.com/docs/) - Documentação Oficial do MongoDB em inglês.
 - [Cursos de MongoDB](#) - Cursos de MongoDB diretamente do repositório geral do Guia Dev Brasil.
 
-## ◾ PostgreeSQL
+## ◾ PostgreSQL
 
 > PostgreSQL é um sistema gerenciador de banco de dados objeto-relacional baseado no POSTGRES, Versão 4.2, desenvolvido na Universidade da Califórnia no Departamento de Ciências da Computação em Berkeley, o qual foi pioneiro em muitos conceitos que vieram a estar disponíveis em alguns bancos de dados comerciais mais tarde.
 
-- [Documentação do PostgreeSQL](https://www.postgresql.org/docs/) - Documentação Oficial do PostgreeSQL em inglês
-- [Documentação do PostgreeSQL em PT-BR](https://ftp.unicamp.br/pub/apoio/postgresql/pgdocptbr800-1.2.pdf) - Documentação do PostgreeSQL em PT-BR
-- [Cursos de PostgreeSQL](#) - Cursos de PostgreeSQL diretamente do repositório geral do Guia Dev Brasil.
+- [Documentação do PostgreSQL](https://www.postgresql.org/docs/) - Documentação Oficial do PostgreSQL em inglês
+- [Documentação do PostgreSQL em PT-BR](https://ftp.unicamp.br/pub/apoio/postgresql/pgdocptbr800-1.2.pdf) - Documentação do PostgreSQL em PT-BR
+- [Cursos de PostgreeSQL](#) - Cursos de PostgreSQL diretamente do repositório geral do Guia Dev Brasil.
 
 ## ◾ SQL
 
@@ -357,7 +357,7 @@ Abaixo você encontrará conteúdos para te guiar e ajudar a se torna um desenvo
 > ASP.NET é a plataforma da Microsoft para o desenvolvimento de aplicações Web e é o sucessor da tecnologia ASP. Permite, através de uma linguagem de programação integrada na .NET Framework, criar páginas dinâmicas. Não é nem uma linguagem de programação como VBScript, PHP, nem um servidor web como IIS ou Apache.
 
 - [ASP - W3Schools](https://www.w3schools.com/asp/default.asp) - W3Schools é um site educacional voltado ao aprendizado de tecnologias web. Seu conteúdo inclui tutoriais e referências relacionadas a diversas linguagens.
-- [Documentação do ASP.net](https://docs.microsoft.com/pt-br/aspnet/core/?view=aspnetcore-6.0) - Documentação Oficial do PostgreeSQL em PT-BR.
+- [Documentação do ASP.net](https://docs.microsoft.com/pt-br/aspnet/core/?view=aspnetcore-6.0) - Documentação Oficial do ASP net em PT-BR.
 - [Cursos de ASP.net](#) - Cursos de ASP.net diretamente do repositório geral do Guia Dev Brasil.
 
 ## ◾ Raspberry Pi
@@ -373,7 +373,7 @@ Abaixo você encontrará conteúdos para te guiar e ajudar a se torna um desenvo
 > Amazon Web Services, também conhecido como AWS, é uma plataforma de serviços de computação em nuvem, que formam uma plataforma de computação na nuvem oferecida pela Amazon.com. Os serviços são oferecidos em várias áreas geográficas distribuídas pelo mundo.
 
 - [AWS Cloud - W3Schools](https://www.w3schools.com/aws/index.php) - W3Schools é um site educacional voltado ao aprendizado de tecnologias web. Seu conteúdo inclui tutoriais e referências relacionadas a diversas linguagens.
-- [Documentação do AWS](https://docs.aws.amazon.com/) - Documentação oficial da linguagem Lua em inglês.
+- [Documentação do AWS](https://docs.aws.amazon.com/) - Documentação oficial AWS Cloud em inglês.
 - [AWS Cloud - Escola da Nuvem](https://www.escoladanuvem.org/cursos/fundamentos-aws/) - A Escola da Nuvem é uma organização da sociedade civil, sem fins lucrativos, que prepara estudantes para carreiras na nuvem e os conecta a empregadores em potencial.
 - [Cursos de AWS](#) - Cursos de AWS diretamente do repositório geral do Guia Dev Brasil.
 


### PR DESCRIPTION
Realização da correção de título e nomes para os seguintes tópicos : PostgreSQL , ASP NET e Raspberry Pi.

Qual era o erro?

PostgreSQL
![image](https://user-images.githubusercontent.com/71945695/210904135-eb2bcdd7-eeab-4883-820e-c2fe3709a4bb.png) 
-> nesse print a palavra PostgreSQL está escrita de outra forma

ASP NET
![image](https://user-images.githubusercontent.com/71945695/210904363-79f8a85d-cac8-4766-a4a7-89d1817f939d.png)
->  nesse print o título do link oficial está dizendo que é da documentação do PostgreSQL

Raspberry Pi
![image](https://user-images.githubusercontent.com/71945695/210904278-5e2720c6-1b07-4956-b879-96600a44f9e4.png)
-> nesse print o título do link oficial está dizendo que é da documentação do PostgreSQL

Obs : Parabéns para quem teve a ideia e criação desse repositório perfeito ✨ A comunidade agradece! 



